### PR TITLE
Error on install wkhtmltopdf

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -9,7 +9,7 @@ export WKHTMLTTOPDF_VERSION="0.12.4"
 function install_wkhtmltopdf {
   if [ ! -f pdf/vendor/wkhtmltopdf ]; then
     echo "Installing wkhtmltopdf."
-    wget -qO- https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTTOPDF_VERSION}/wkhtmltox-${WKHTMLTTOPDF_VERSION}_linux-generic-amd64.tar.xz | tar xvz
+    wget -qO- https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTTOPDF_VERSION}/wkhtmltox-${WKHTMLTTOPDF_VERSION}_linux-generic-amd64.tar.xz | tar xpJ
     cp wkhtmltox/bin/wkhtmltopdf pdf/vendor/
     cp wkhtmltox/bin/wkhtmltopdf pdf/
     rm -rf wkhtmltox/


### PR DESCRIPTION
Command: ```make build```

Error:
```
+ echo 'Installing wkhtmltopdf.'
Installing wkhtmltopdf.
+ wget -qO- https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+ tar xvz

gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
Makefile:2: recipe for target 'build' failed
make: *** [build] Error 2
```
Env:
```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 17.10
Release:	17.10
Codename:	artful
```